### PR TITLE
Fix the references of the yjit-bench repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - ruby: head
           - ruby: truffleruby
             skip: protoboeuf-encode ruby-lsp shipit
-    if: ${{ github.event_name != 'schedule' || github.repository == 'Shopify/yjit-bench' }}
+    if: ${{ github.event_name != 'schedule' || github.repository == 'ruby/yjit-bench' }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,16 @@ We'd love your contributions! Folks have contributed new benchmarks, new test ha
 and more. I'm sure there's more you'd like to see in yjit-bench.
 
 If you have questions or problems getting set up, you're probably not the only
-one with difficulties. You can [file an issue](https://github.com/Shopify/yjit-bench/issues)
+one with difficulties. You can [file an issue](https://github.com/ruby/yjit-bench/issues)
 and we'll answer as soon as we can.
 
-We welcome [GitHub Pull Requests](https://github.com/Shopify/yjit-bench/pulls) in 
+We welcome [GitHub Pull Requests](https://github.com/ruby/yjit-bench/pulls) in
 the usual way, though you'll need to sign a Shopify
 Contributor License Agreement - when you file the PR a bot should direct you through
 the process.
 
 If you're looking for something to do, the
-[issue tracker](https://github.com/Shopify/yjit-bench/issues)
+[issue tracker](https://github.com/ruby/yjit-bench/issues)
 can also be helpful.
 
 Right now documentation is mostly in the benchmark files and in the README.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ graphed in any spreadsheet editor.
 
 Clone this repository:
 ```
-git clone https://github.com/Shopify/yjit-bench.git yjit-bench
+git clone https://github.com/ruby/yjit-bench.git yjit-bench
 ```
 
 ### Benchmarking YJIT


### PR DESCRIPTION
We've just transferred `Shopify/yjit-bench` to `ruby/yjit-bench`.